### PR TITLE
remove usage of RangedData

### DIFF
--- a/bin/nucleR.R
+++ b/bin/nucleR.R
@@ -13,6 +13,7 @@ suppressPackageStartupMessages(library(htSeqTools))
 suppressPackageStartupMessages(library(nucleR))
 suppressPackageStartupMessages(library(IRanges))
 suppressPackageStartupMessages(library(GenomicRanges))
+suppressPackageStartupMessages(library(parallel))
 
 where <- function () {
     spath <-parent.frame(2)$ofile
@@ -115,7 +116,6 @@ if (params$threshold) {
 
 message("loading data")
 reads <- get(load(params$input))
-#reads <- RangedData(reads$ranges, space  = droplevels(reads$space))
 reads <- keepSeqlevels(reads, seqlevelsInUse(reads))
 
 message("filtering duplicated reads")

--- a/bin/periodicity.R
+++ b/bin/periodicity.R
@@ -13,6 +13,7 @@ suppressPackageStartupMessages(library(getopt))
 suppressPackageStartupMessages(library(plyr))
 suppressPackageStartupMessages(library(nucleR))
 suppressPackageStartupMessages(library(htSeqTools))
+suppressPackageStartupMessages(library(plyranges))
 
 where <- function () {
     spath <-parent.frame(2)$ofile
@@ -64,13 +65,12 @@ for (i in names(args)) {
 ## Some function definitions ##################################################
 
 message("loading genes")
-genes <- getGenes(params$genes)
+
+genes <- read_gff3(params$genes)
 message("reading calls")
+
 calls.df <- readGff(params$calls)
-calls.rd <- with(calls.df,
-                 RangedData(space=seqname,
-                            range=IRanges(start=start,
-                                          end=end)))
+names(calls.df)[1] <- "seqnames"
 
 ## Do it ######################################################################
 
@@ -92,7 +92,8 @@ prep <- processReads(f.reads,
 cov <- coverage.rpm(prep)
 
 message("identifying first and last nucleosomes")
-genes.nucs <- findGenesNucs(genes, calls.rd, params$mc.cores)
+
+genes.nucs <- findGenesNucs(genes, as_granges(calls.df), params$mc.cores)
 genes.nucs$dfi <- getDfi(genes.nucs$nuc.len, params$periodicity)
 genes.nucs$autocor <- autocorFromDf(genes.nucs, cov, params$periodicity)
 

--- a/bin/txstart.R
+++ b/bin/txstart.R
@@ -16,6 +16,8 @@ suppressPackageStartupMessages(library(IRanges))
 suppressPackageStartupMessages(library(GenomicRanges))
 suppressPackageStartupMessages(library(htSeqTools))
 suppressPackageStartupMessages(library(nucleR))
+suppressPackageStartupMessages(library(plyranges))
+suppressPackageStartupMessages(library(parallel))
 
 where <- function () {
     spath <-parent.frame(2)$ofile
@@ -70,32 +72,25 @@ for (i in names(args)) {
 ## Some function declarations #################################################
 
 message("-- loading inputs")
-nucs <- with(readGff(params$calls),
-             RangedData(ranges  = IRanges(start = as.numeric(start),
-                                          end   = as.numeric(end)),
-                        space   = as.character(seqname),
-                        score   = as.numeric(score),
-                        score_w = as.numeric(score_width),
-                        score_h = as.numeric(score_height),
-                        #nmerge  = as.numeric(nmerge),
-                        class   = as.character(class)))
+nucs <- read_gff3(params$calls)
 
 ## Read input #################################################################
 
 message("-- loading used genome")
-genes <- getGenes(params$genome)
+genes <- read_gff3(params$genome)
 
 genes$tss <- as.numeric(genes$tss)
 genes$tts <- as.numeric(genes$tts)
 
 ## Do it ######################################################################
 
+
 message("-- checking the classes")
 tx.classes <- with(params,
                    patternsByChrDF(calls             = nucs,
-                                   df                = genes,
+                                   df                = as.data.frame(genes),
                                    col.id            = "name",
-                                   col.chrom         = "chrom",
+                                   col.chrom         = "seqnames",
                                    col.pos           = "tss",
                                    col.strand        = "strand",
                                    window            = window,

--- a/statistics/nucDyn.R
+++ b/statistics/nucDyn.R
@@ -3,11 +3,11 @@
 ## Imports ####################################################################
 
 suppressPackageStartupMessages(library(getopt))
-suppressPackageStartupMessages(library(htSeqTools))
 suppressPackageStartupMessages(library(nucleR))
 suppressPackageStartupMessages(library(IRanges))
 suppressPackageStartupMessages(library(GenomicRanges))
 suppressPackageStartupMessages(library(ggplot2))
+suppressPackageStartupMessages(library(plyranges))
 
 where <- function () {
     spath <-parent.frame(2)$ofile
@@ -43,13 +43,13 @@ params <- getopt(spec)
 ## Read genes #################################################################
 
 message("-- loading used genome")
-genes <- getGenes(params$genome)
+genes <- read_gff3(params$genome)
 
 genes$tss <- as.numeric(genes$tss)
 genes$tts <- as.numeric(genes$tts)
 
-genes_gr <- GRanges(genes$chrom,
-                    IRanges(start=genes$start, end=genes$end),
+genes_gr <- GRanges(as.vector(seqnames(genes)),
+                    IRanges(start=start(genes), end=end(genes)),
                     name=genes$name)
 
 ## Statistics per gene ########################################################
@@ -80,7 +80,7 @@ i <- c("name",
        "nEvic",
        "nShift_p",
        "nShift_m")
-stat_nd <- genes[, i]
+stat_nd <- as.data.frame(genes)[, i]
 
 stat_nd <- rbind(c("Name",
                    "Inclusions",

--- a/statistics/nucleR.R
+++ b/statistics/nucleR.R
@@ -5,6 +5,7 @@
 suppressPackageStartupMessages(library(getopt))
 suppressPackageStartupMessages(library(IRanges))
 suppressPackageStartupMessages(library(GenomicRanges))
+suppressPackageStartupMessages(library(plyranges))
 
 where <- function () {
     spath <-parent.frame(2)$ofile
@@ -40,18 +41,20 @@ params <- getopt(spec)
 ## Read genes #################################################################
 
 message("-- loading used genome")
-genes <- getGenes(params$genome)
+
+genes <- read_gff3(params$genome)
 
 genes$tss <- as.numeric(genes$tss)
 genes$tts <- as.numeric(genes$tts)
 
-genes_gr <- GRanges(genes$chrom,
-                    IRanges(start=genes$start, end=genes$end),
+genes_gr <- GRanges(as.vector(seqnames(genes)),
+                    IRanges(start=start(genes), end=end(genes)),
                     name=genes$name)
 
 ## Statistics per gene ########################################################
 
 message("-- computing statistics per gene")
+
 nuc <- readGff(params$input)
 
 nuc_gr <- GRanges(nuc$seqname,
@@ -74,12 +77,12 @@ cols <- c("name",
           "TotalUncertain")
 genes_out = genes[, cols]
 
-cols <- c("Name",
-          "Total Nucleosomes",
-          "Total Well-Positioned",
-          "Total Fuzzy",
-          "Total Uncertain")
-genes_out = rbind(cols, genes_out)
+# cols <- c("Name",
+#           "Total Nucleosomes",
+#           "Total Well-Positioned",
+#           "Total Fuzzy",
+#           "Total Uncertain")
+# genes_out = rbind(cols, genes_out)
 
 write.table(genes_out,
             params$out_genes,

--- a/statistics/periodicity.R
+++ b/statistics/periodicity.R
@@ -6,6 +6,7 @@
 suppressPackageStartupMessages(library(getopt))
 suppressPackageStartupMessages(library(IRanges))
 suppressPackageStartupMessages(library(GenomicRanges))
+suppressPackageStartupMessages(library(plyranges))
 
 where <- function () {
     spath <-parent.frame(2)$ofile
@@ -40,7 +41,7 @@ params <- getopt(spec)
 ## Read genes #################################################################
 
 message("-- loading used genome")
-genes <- getGenes(params$genome)
+genes <- read_gff3(params$genome) %>% as.data.frame()
 
 genes$tss <- as.numeric(genes$tss)
 genes$tts <- as.numeric(genes$tts)
@@ -57,7 +58,7 @@ genes_out = merge(genes[, c("name", "tss")],
                   by.x="name",
                   by.y="id",
                   all.x=TRUE)
-genes_out = genes_out[, c(1, 3, 4)]
+genes_out = genes_out[, c("name", "score_phase", "score_autocorrelation")]
 names <- c("Name", "Score phase", "Score autocorrelation")
 genes_out = rbind(names, genes_out)
 

--- a/statistics/stiffness.R
+++ b/statistics/stiffness.R
@@ -6,6 +6,7 @@ suppressPackageStartupMessages(library(getopt))
 suppressPackageStartupMessages(library(IRanges))
 suppressPackageStartupMessages(library(GenomicRanges))
 suppressPackageStartupMessages(library(ggplot2))
+suppressPackageStartupMessages(library(plyranges))
 
 where <- function () {
     spath <-parent.frame(2)$ofile
@@ -41,14 +42,17 @@ params <- getopt(spec)
 ## Read genes #################################################################
 
 message("-- loading used genome")
-genes <- getGenes(params$genome)
+
+
+genes <- read_gff3(params$genome) %>% as.data.frame()
 
 genes$tss <- as.numeric(genes$tss)
 genes$tts <- as.numeric(genes$tts)
 
-genes_gr <- GRanges(genes$chrom,
+genes_gr <- GRanges(genes$seqnames,
                     IRanges(start=genes$start, end=genes$end),
                     name=genes$name)
+
 
 ## Statistics per gene ########################################################
 

--- a/statistics/txstart.R
+++ b/statistics/txstart.R
@@ -7,6 +7,7 @@ suppressPackageStartupMessages(library(getopt))
 suppressPackageStartupMessages(library(IRanges))
 suppressPackageStartupMessages(library(GenomicRanges))
 suppressPackageStartupMessages(library(ggplot2))
+suppressPackageStartupMessages(library(plyranges))
 
 where <- function () {
     spath <-parent.frame(2)$ofile
@@ -43,7 +44,7 @@ params <- getopt(spec)
 ## Read genes #################################################################
 
 message("-- loading used genome")
-genes <- getGenes(params$genome)
+genes <- read_gff3(params$genome) %>% as.data.frame()
 
 genes$tss <- as.numeric(genes$tss)
 genes$tts <- as.numeric(genes$tts)


### PR DESCRIPTION
Hi, 

I removed usage of the depreciated `RangedData`-Type by using the `plyranges` package to read data and subsequently change some helper functions to work with `GRanges` instead of `RangedData`. 

Additionally sometimes the `parallel` package was missing - but this might be something specific to my system. 

bw
Simon 
 